### PR TITLE
YoloE: evaluation batch size is same as the one of train

### DIFF
--- a/autonn/YoloE/yoloe_core/yolov7_utils/train.py
+++ b/autonn/YoloE/yoloe_core/yolov7_utils/train.py
@@ -417,7 +417,7 @@ def train(hyp, opt, device, tb_writer=None):
             if not opt.notest or final_epoch:  # Calculate mAP
                 wandb_logger.current_epoch = epoch + 1
                 results, maps, times = test.test(data_dict,
-                                                 batch_size=batch_size * 2,
+                                                 batch_size=batch_size, # multiplying by 2 may cause out of gpu memory
                                                  imgsz=imgsz_test,
                                                  model=ema.ema,
                                                  single_cls=opt.single_cls,

--- a/autonn/YoloE/yoloe_core/yolov7_utils/train_aux.py
+++ b/autonn/YoloE/yoloe_core/yolov7_utils/train_aux.py
@@ -412,7 +412,7 @@ def train(hyp, opt, device, tb_writer=None):
             if not opt.notest or final_epoch:  # Calculate mAP
                 wandb_logger.current_epoch = epoch + 1
                 results, maps, times = test.test(data_dict,
-                                                 batch_size=batch_size * 2,
+                                                 batch_size=batch_size, # multiplying by 2 may cause out of gpu memory
                                                  imgsz=imgsz_test,
                                                  model=ema.ema,
                                                  single_cls=opt.single_cls,


### PR DESCRIPTION
YoloE가 테스트 수행 시에 batch size를 train batch size의 2배를 하는 방식에서 train의 batch size를 그대로 사용하는 방식으로 변경되었습니다.