### PR TITLE
[fix] resnet classifier

### DIFF
--- a/autonn/ResNet/resnet_core/resnet_utils/train.py
+++ b/autonn/ResNet/resnet_core/resnet_utils/train.py
@@ -114,7 +114,7 @@ def run_resnet(proj_path: str, dataset_yaml_path: str):
         basemodel_info: dict = yaml.safe_load(f)
 
 
-    device = torch.device("cuda" if torch.cuda.is_available() and project_info.get("acc", "cpu") == "cuda" else "cpu")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     batch_size: int = project_info.get("batch_size", 3)
 
     layers: List[int] = basemodel_info.get("layers", [3, 3, 3])

--- a/autonn/ResNet/resnet_core/views.py
+++ b/autonn/ResNet/resnet_core/views.py
@@ -242,7 +242,13 @@ def autogen_resnet(userid, project_id):
 
     nn_model_path.mkdir(parents=True, exist_ok=True)
     (nn_model_path / "models").mkdir(parents=True, exist_ok=True)
-    model_file = source_root / "pretrained/kagglecxr_resnet152_normalize.pt"
+    if Path(source_root / "pretrained/kagglecxr_resnet152_normalize.pt").exists():
+        model_file = source_root / "pretrained/kagglecxr_resnet152_normalize.pt"
+    elif Path(project_root / "weights" / "best.pt").exists():
+        model_file = project_root / "weights" / "best.pt"
+    else:
+        model_file = project_root / "weights" / "last.pt"
+
     shutil.copy(model_file, nn_model_path / "resnet.pt")
     shutil.copy(project_root / "basemodel.yaml", nn_model_path / "basemodel.yaml")
     shutil.copy(source_root / "resnet_utils/inference.py", nn_model_path / "inference.py")


### PR DESCRIPTION
# 오류 수정

- 이제부터 target의 가속방식을 훈련서버에서 고려하지 않습니다.
- 배포모델을 준비할 때 발생하는 경로 오류를 수정하였습니다.