### PR TITLE
fix: Hide 'Chat' Task Type from Project Setting screen

### DIFF
--- a/project_manager/frontend/src/modules/project/stepper/ProjectConfigurationSettingV2.vue
+++ b/project_manager/frontend/src/modules/project/stepper/ProjectConfigurationSettingV2.vue
@@ -9,7 +9,7 @@
         <v-radio-group v-model="taskType" row hide-details="" class="ma-0">
           <v-radio label="Classification" :value="TaskType.CLASSIFICATION"></v-radio>
           <v-radio label="Detection" :value="TaskType.DETECTION"></v-radio>
-          <v-radio label="Chat" :value="TaskType.CHAT"></v-radio>
+          <!-- <v-radio label="Chat" :value="TaskType.CHAT"></v-radio> -->
         </v-radio-group>
       </div>
 

--- a/project_manager/frontend/src/modules/project/tabs/ConfigurationTab.vue
+++ b/project_manager/frontend/src/modules/project/tabs/ConfigurationTab.vue
@@ -11,7 +11,7 @@
         <v-radio-group v-model="taskType" row hide-details class="ma-0 mt-2 ml-3" readonly>
           <v-radio label="Classification" :value="TaskType.CLASSIFICATION"></v-radio>
           <v-radio label="Detection" :value="TaskType.DETECTION"></v-radio>
-          <v-radio label="Chat" :value="TaskType.CHAT"></v-radio>
+          <!-- <v-radio label="Chat" :value="TaskType.CHAT"></v-radio> -->
         </v-radio-group>
       </div>
     </div>


### PR DESCRIPTION
The 'Chat' Task Type should not be displayed in the Task Type list, but it was incorrectly shown.
- Updated logic to exclude 'Chat' from the Task Type list

### PR 타입
하나 이상의 PR 타입을 선택해주세요.
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

### PR전 체크 사항
PR전 아래 사항을 확인하였는지 체크하시고 PR 생성 바랍니다.
- [X] 자신의 브랜치로 main 브랜치 최신 내용 반영후 동작 테스트 완료
- [X] 다른 작업자의 폴더내 파일 수정하지 않음.
- [X] docker-compose.yml 수정한 경우, 수정에 따른 영향 평가 

### 관련 이슈
#220  Task Type에서 'Chat'이 표시되지 않아야 함
### PR 반영 브랜치
teslasystem_vue -> main

### 변경 사항
Tasktype에서 Chat이 표시되지 않도록 수정

### 테스트 결과
화면에 Chat이 표시되지 않는지 확인
