### PR TITLE
feat(makefile): enhance prepare-v1-compose for GPU runtime & env merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,25 @@ endif
 
 # v2 전용 플래그 (v1은 해당 플래그 미지원)
 ifeq ($(COMPOSE),docker compose)
+COMPOSE_FILE_FLAG :=
 CONFIG_ENV_FILE_FLAG := --env-file .env
 else
+COMPOSE_FILE_FLAG := -f .docker-v1compose.yml
 CONFIG_ENV_FILE_FLAG :=
+NEEDS_PREPARE := prepare-v1-compose
 endif
 
 SHELL := /bin/bash
 .ONESHELL:
 .DEFAULT_GOAL := help
 
-# .env 값을 make 환경으로 불러오기 (없어도 동작은 함)
+# .env 값을 make 환경으로 불러오기
 -include .env
 export
 
 .PHONY: help build clean-labelling-db up down restart logs pm-logs autonn-logs config recreate \
-        check-datasets run exec-pm exec-autonn migrate seed up-% logs-%
+        ps check-datasets run exec-pm exec-autonn migrate seed up-% logs-% build-% \
+		prepare-v1-compose clean-v1-compose
 
 help: ## 사용 가능한 명령 목록
 	@grep -hE '^[a-zA-Z0-9_%-]+:.*?## ' $(MAKEFILE_LIST) | \
@@ -49,52 +53,150 @@ clean-labelling-db: ## (자동) labelling/datadb 폴더가 있으면 삭제
 		echo "✓ labelling/datadb 없음 — skip"; \
 	fi
 
-build: clean-labelling-db ## 이미지 빌드
-	$(COMPOSE) build
+# ---- v1용 파일 자동 생성
+prepare-v1-compose: ## docker-compose v1용 파일 자동 생성 (deploy 제거 + runtime 주입 + env 병합)
+	@echo "🛠  Generating .docker-v1compose.yml for v1 (merge env keys)..."
+	@if [ ! -f docker-compose.yml ]; then echo "❌ docker-compose.yml not found!"; exit 1; fi
+	@awk '\
+	  # 대상 서비스 판별
+	  function is_target_service(line){ return match(line,/^  (autonn|autonn_cl):/); } \
+	  \
+	  BEGIN{ in_svc=0; in_deploy=0; in_env=0; \
+	         seen_env=0; need_env=0; \
+	         found_vis=0; found_caps=0; \
+	       } \
+	  { \
+	    # 서비스 시작
+	    if (is_target_service($$0)) { \
+	      in_svc=1; in_deploy=0; in_env=0; \
+	      seen_env=0; need_env=0; found_vis=0; found_caps=0; \
+	    } \
+	    # 서비스 종료(같은 레벨의 다른 키/서비스 진입)
+	    else if (in_svc && $$0 ~ /^  [^[:space:]].*:/ && !is_target_service($$0)) { \
+	      if (in_env){ \
+	        if (!found_vis)  print "      - NVIDIA_VISIBLE_DEVICES=$${NVIDIA_VISIBLE_DEVICES:-all}"; \
+	        if (!found_caps) print "      - NVIDIA_DRIVER_CAPABILITIES=compute,utility"; \
+	        in_env=0; \
+	      } \
+	      if (need_env && !seen_env){ \
+	        print "    environment:"; \
+	        print "      - NVIDIA_VISIBLE_DEVICES=$${NVIDIA_VISIBLE_DEVICES:-all}"; \
+	        print "      - NVIDIA_DRIVER_CAPABILITIES=compute,utility"; \
+	      } \
+	      in_svc=0; in_deploy=0; \
+	    } \
+	    \
+	    # 서비스 내부 처리
+	    if (in_svc) { \
+	      # deploy: → runtime 주입, deploy 블록은 스킵
+	      if ($$0 ~ /^[[:space:]]{4}deploy:/){ \
+	        print "    runtime: nvidia"; \
+	        need_env=1; in_deploy=1; next; \
+	      } \
+	      if (in_deploy){ \
+	        match($$0,/^[[:space:]]*/); \
+	        if (RLENGTH <= 4){ in_deploy=0; } else { next; } \
+	      } \
+	      # gpus: 라인 제거
+	      if ($$0 ~ /^[[:space:]]+gpus:/){ next; } \
+	      \
+	      # environment: 블록 진입
+	      if ($$0 ~ /^[[:space:]]{4}environment:/){ \
+	        in_env=1; seen_env=1; print $$0; next; \
+	      } \
+	      # environment: 블록 내부 처리(리스트 가정)
+	      if (in_env){ \
+	        # 블록 종료 감지: 4스페이스 새 키 시작
+	        if ($$0 ~ /^[[:space:]]{4}[^[:space:]]/){ \
+	          if (!found_vis)  print "      - NVIDIA_VISIBLE_DEVICES=$${NVIDIA_VISIBLE_DEVICES:-all}"; \
+	          if (!found_caps) print "      - NVIDIA_DRIVER_CAPABILITIES=compute,utility"; \
+	          in_env=0; \
+	          # 이후 일반 처리로 현재 줄 출력 \
+	        } else { \
+	          if ($$0 ~ /^[[:space:]]{6}-[[:space:]]*NVIDIA_VISIBLE_DEVICES=/) { found_vis=1; } \
+	          if ($$0 ~ /^[[:space:]]{6}-[[:space:]]*NVIDIA_DRIVER_CAPABILITIES=/) { found_caps=1; } \
+	          print $$0; \
+	          next; \
+	        } \
+	      } \
+	    } \
+	    \
+	    # 기본 출력
+	    print $$0; \
+	  } \
+	  END{ \
+	    # 파일이 env 블록 중에 끝난 케이스 처리 \
+	    if (in_env){ \
+	      if (!found_vis)  print "      - NVIDIA_VISIBLE_DEVICES=$${NVIDIA_VISIBLE_DEVICES:-all}"; \
+	      if (!found_caps) print "      - NVIDIA_DRIVER_CAPABILITIES=compute,utility"; \
+	    } \
+	    # 파일이 서비스 중에 끝났고 env가 없는데 deploy는 있었던 케이스 \
+	    if (in_svc && need_env && !seen_env){ \
+	      print "    environment:"; \
+	      print "      - NVIDIA_VISIBLE_DEVICES=$${NVIDIA_VISIBLE_DEVICES:-all}"; \
+	      print "      - NVIDIA_DRIVER_CAPABILITIES=compute,utility"; \
+	    } \
+	  }' docker-compose.yml > .docker-v1compose.yml
+	@echo "✅ .docker-v1compose.yml 생성 완료 (deploy 제거 + runtime 주입 + env 병합)"
 
-up: ## 모든 서비스 시작 (-d)
-	$(COMPOSE) up -d
+clean-v1-compose:
+	@if [ -f .docker-v1compose.yml ]; then rm -f .docker-v1compose.yml && echo "🧹 removed .docker-v1compose.yml"; else echo "✓ no temp file"; fi
+
+build: $(NEEDS_PREPARE) clean-labelling-db ## 이미지 빌드
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) build
+
+build-%: $(NEEDS_PREPARE) ## 특정 서비스만 빌드 (예: make build-autonn)
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) build $*
+
+up: $(NEEDS_PREPARE) ## 모든 서비스 시작 (-d)
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) up -d
 
 down: ## 중지 및 제거
-	$(COMPOSE) down
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) down
 
 restart: down up ## 재시작
 
 recreate: ## 볼륨/환경 변경 반영해 재생성(빌드는 안 함)
-	$(COMPOSE) up -d --force-recreate
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) up -d --force-recreate
 
-config: ## .env 적용된 최종 compose 확인
-	$(COMPOSE) $(CONFIG_ENV_FILE_FLAG) .env config
+config: $(NEEDS_PREPARE) ## .env 적용된 최종 compose 확인
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) $(CONFIG_ENV_FILE_FLAG) config
+
+ps: ## 컨테이너 상태 보기
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) ps
 
 # ---- 로그/접속/관리
 logs: ## 전체 로그 팔로우
-	$(COMPOSE) logs -f
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) logs -f || true
 
 pm-logs: ## project_manager 로그
-	$(COMPOSE) logs -f project_manager
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) logs -f project_manager || true
 
 autonn-logs: ## autonn 로그
-	$(COMPOSE) logs -f autonn
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) logs -f autonn || true
 
 exec-pm: ## project_manager 쉘
-	$(COMPOSE) exec project_manager bash
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) exec project_manager bash
 
 exec-autonn: ## autonn 쉘
-	$(COMPOSE) exec autonn bash
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) exec autonn bash
 
 # 패턴 타겟: make up-autonn / make logs-project_manager 처럼 사용
 up-%: ## 특정 서비스만 up (예: make up-autonn)
-	$(COMPOSE) up -d $*
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) up -d $*
 
 logs-%: ## 특정 서비스 로그 (예: make logs-project_manager)
-	$(COMPOSE) logs -f $*
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) logs -f $* || true
+
+exec-%: ## 특정 서비스 쉘 (예: make exec-autonn)
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) exec $* bash
 
 # ---- Django 보조
 migrate: ## project_manager DB migrate
-	$(COMPOSE) exec project_manager bash -lc 'python manage.py migrate'
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) exec project_manager bash -lc 'python manage.py migrate'
 
 seed: ## project_manager loaddata
-	$(COMPOSE) exec project_manager bash -lc 'python manage.py loaddata base_model_data.json'
+	$(COMPOSE) $(COMPOSE_FILE_FLAG) exec project_manager bash -lc 'python manage.py loaddata base_model_data.json'
 
 # ---- 안전장치
 check-datasets: ## 데이터셋 디렉토리 존재/비어있음 체크

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,17 @@ services:
       sh -c "python manage.py makemigrations &&
              python manage.py migrate &&
              python manage.py runserver 0.0.0.0:8100"
-    gpus: all
-    environment:
-      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-all}
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities:
+                - gpu
+                - utility
+                - compute
+                - video
     volumes:
       - ./autonn/autonn:/source
       - shared:/shared
@@ -173,8 +180,6 @@ services:
                   - utility
                   - compute
                   - video
-      environment:
-        - NVIDIA_VISIBLE_DEVICES=${GPU_NUM:-all}
       volumes:
         - ./autonn_cl/autonn_cl:/source
         - shared:/shared


### PR DESCRIPTION
### PR 타입
하나 이상의 PR 타입을 선택해주세요.
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

### PR전 체크 사항
PR전 아래 사항을 확인하였는지 체크하시고 PR 생성 바랍니다.
- [X] 자신의 브랜치로 main 브랜치 최신 내용 반영후 동작 테스트 완료
- [X] 다른 작업자의 폴더내 파일 수정하지 않음.
- [X] docker-compose.yml 수정한 경우, 수정에 따른 영향 평가 

### 관련 이슈

### PR 반영 브랜치
ETRI-tenace-AutoNN -> main

### 변경 사항
- Automatically detects whether the system uses Docker Compose v1 (docker-compose) or v2 (docker compose).

- For v2, the existing docker-compose.yml is used as-is.

- For v1, the Makefile automatically:

  : Generates a temporary .docker-v1compose.yml file.

  : Removes unsupported deploy: sections.

  : Inserts the following GPU runtime configuration:
  

### 테스트 결과
```bash
make
  help               사용 가능한 명령 목록
  run                데이터셋 확인→ 빌드→ 실행→ 로그 팔로우
  clean-labelling-db (자동) labelling/datadb 폴더가 있으면 삭제
  prepare-v1-compose docker-compose v1용 파일 자동 생성 (deploy 제거 + runtime 주입 + env 병합)
  build              이미지 빌드
  build-%            특정 서비스만 빌드 (예: make build-autonn)
  up                 모든 서비스 시작 (-d)
  down               중지 및 제거
  restart            재시작
  recreate           볼륨/환경 변경 반영해 재생성(빌드는 안 함)
  config             .env 적용된 최종 compose 확인
  ps                 컨테이너 상태 보기
  logs               전체 로그 팔로우
  pm-logs            project_manager 로그
  autonn-logs        autonn 로그
  exec-pm            project_manager 쉘
  exec-autonn        autonn 쉘
  up-%               특정 서비스만 up (예: make up-autonn)
  logs-%             특정 서비스 로그 (예: make logs-project_manager)
  exec-%             특정 서비스 쉘 (예: make exec-autonn)
  migrate            project_manager DB migrate
  seed               project_manager loaddata
  check-datasets     데이터셋 디렉토리 존재/비어있음 체크


make up
docker compose  up -d
[+] Running 9/9
 ✔ Network tango_release_default              Created                                                                                                                                              0.0s 
 ✔ Container tango_release-postgresql-1       Started                                                                                                                                              0.6s 
 ✔ Container tango_release-autonn-1           Started                                                                                                                                              2.6s 
 ✔ Container tango_release-code_gen-1         Started                                                                                                                                              0.6s 
 ✔ Container tango_release-ondevice_deploy-1  Started                                                                                                                                              0.6s 
 ✔ Container tango_release-autonn_cl-1        Started                                                                                                                                              2.6s 
 ✔ Container tango_release-cloud_deploy-1     Started                                                                                                                                              0.6s 
 ✔ Container tango_release-labelling-1        Started                                                                                                                                              0.5s 
 ✔ Container tango_release-project_manager-1  Started 

make logs-autonn
docker compose  logs -f autonn || true
autonn-1  | 
autonn-1  | ==========
autonn-1  | == CUDA ==
autonn-1  | ==========
autonn-1  | 
autonn-1  | CUDA Version 11.3.1
autonn-1  | 
autonn-1  | Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
autonn-1  | 
autonn-1  | This container image and its contents are governed by the NVIDIA Deep Learning Container License.
autonn-1  | By pulling and using the container, you accept the terms and conditions of this license:
autonn-1  | https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license
autonn-1  | 
autonn-1  | A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.
autonn-1  | 
autonn-1  | No changes detected
autonn-1  | Operations to perform:
autonn-1  |   Apply all migrations: admin, auth, autonn_core, contenttypes, sessions
autonn-1  | Running migrations:
autonn-1  |   No migrations to apply.
autonn-1  | Watching for file changes with StatReloader
autonn-1  | Performing system checks...
autonn-1  | 
autonn-1  | System check identified no issues (0 silenced).
autonn-1  | October 27, 2025 - 16:02:19
autonn-1  | Django version 3.2.25, using settings 'config.settings'
autonn-1  | Starting development server at http://0.0.0.0:8100/
autonn-1  | Quit the server with CONTROL-C.


make down
docker compose  down
[+] Running 9/9
 ✔ Container tango_release-labelling-1        Removed                                                                                                                                             10.6s 
 ✔ Container tango_release-ondevice_deploy-1  Removed                                                                                                                                             10.3s 
 ✔ Container tango_release-code_gen-1         Removed                                                                                                                                             10.4s 
 ✔ Container tango_release-autonn-1           Removed                                                                                                                                             10.6s 
 ✔ Container tango_release-cloud_deploy-1     Removed                                                                                                                                              4.3s 
 ✔ Container tango_release-autonn_cl-1        Removed                                                                                                                                             10.6s 
 ✔ Container tango_release-project_manager-1  Removed                                                                                                                                             10.5s 
 ✔ Container tango_release-postgresql-1       Removed                                                                                                                                              0.2s 
 ✔ Network tango_release_default              Removed  

